### PR TITLE
删除 border-spacing: 0;

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -32,7 +32,7 @@ input,select,textarea {
 
 /* 去掉各Table  cell 的边距并让其边重合 */
 table {
-    border-collapse:collapse;border-spacing:0;
+    border-collapse:collapse;
 }
 
 /* IE bug fixed: th 不继承 text-align*/


### PR DESCRIPTION
经过实验，在各浏览器下，border-collapse: collapse; border-spacing: 0; 和 border-collapse: collapse; 效果完全一致，没有任何差别，故删除 border-spacing: 0;。
